### PR TITLE
ET-10897: Add support for partner user upload processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,84 @@ set['openssh']['server']['match'] = {
 }
 ```
 
+## Files
+
+### recipe/scripts
+
+Performs several setup steps that are required for processing uploads and exports.  This script does the following:
+
+1. Setup the rotation schedule for /var/log/process\_uploads.log and /var/log/process\_scheduled\_exports.log
+2. Create /opt/evertrue/config.xml
+3. Setup cron schedules for processing uploads and exports and removing old upload and export files
+
+### recipe/users
+
+Manages folder structure of all upload users.  This script does the following:
+
+1. Load the upload.json content from the users databag
+2. For each user do the following:
+3. Determine the home folder of the user.  For most users the folder will be /mnt/dev0/evertrue/users/{username}.  However, if the parent\_user and partner values have been set for the user then the home folder will be a subfolder under the parent\_user named for the partner.
+4. If the user's action is remove then delete the user's home directory and all files, otherwise do the following:
+  5. Create the OS user and set the home folder
+  6. Create the user's home folder
+  7. If the user is using SSH keys then store those in the .ssh folder
+  8. Create the uploads and exports folders under the home folder
+
+An example user object from the upload.json file:
+
+```
+  "givingtreedemo": {
+    "uid": 10150,
+    "ssh_keys": [],
+    "comment": "Chelsea Leavitt GivingTree Demo",
+    "password": "abc"
+  }
+```
+
+An example parter user object:
+
+```
+  "givingtreedemo-hustle": {
+    "uid": 10663,
+    "ssh_keys": [],
+    "parent_user": "givingtreedemo",
+    "partner": "hustle",
+    "comment": "GivingTree Demo Hustle Access",
+    "password": "abc"
+  }
+```
+
+
+### files/default/process\_uploads
+
+Sends files from the uploads directory for import processing.  This script does the following:
+
+1. Load /opt/evertrue/config.xml
+2. For each value in unames, do the following:
+3. Get all file names stored under any uploads folder under the uname home folder
+4. Ignore any upload file that does not have a csv, gz or zip extension.
+5. Determine the type of import from the name of the upload file
+6. Copy the upload file to the org's S3 folder
+7. Check that a mapping exists for the upload file's headers
+8. Post the upload file to the importer
+9. If a mapping exists then queue the import file for processing if `ET.Importer.IngestionMode = AutoIngest`
+10. If a mapping does not exist then notify support and set `ET.Importer.IngestionMode = NotifyOnly`
+
+Logs for this script are saved to /var/log/process\_uploads.log
+
+### files/default/process\_scheduled\_exports
+
+Copies scheduled export files to the org's SFTP folder for download.  This script does the following:
+
+1. Load /opt/evertrue/config.xml
+2. For each value in unames, do the following:
+3. Get the oid from the uname value.  Note that not all unames map directly to an org slug
+4. Get the latest scheduled exports for the oid via /contacts/v2/exports/latest-scheduled
+5. Download each export file via /contacts/v2/exports
+6. Save the export file to the uname home exports folder
+
+Logs for this script are saved to /var/log/process\_scheduled\_exports.log
+
 ## Usage
 
 ### et_upload::default

--- a/files/default/process_uploads
+++ b/files/default/process_uploads
@@ -356,9 +356,11 @@ def email_notify(msg)
   )
 end
 
-def order_files_by_upload_time(files)
-  files
+def order_files_by_upload_time(base_dir)
+  # Identify all files found under uploads folders at any folder level
+  Dir.glob(base_dir + "/**/**")
     .select { |f| File.file?(f) } # filter out none files
+    .select { |path| path =~ /\/uploads\// } # only include files under the uploads path
     .sort_by { |f| File.ctime(f) } # order by creation date
 end
 
@@ -389,7 +391,7 @@ def main
 
     begin
       logger.debug 'Searching for files to upload'
-      order_files_by_upload_time(Dir.glob("#{conf[:upload_dir]}/#{uname}/uploads/*")).each do |path|
+      order_files_by_upload_time("#{conf[:upload_dir]}/#{uname}")).each do |path|
         logger.debug "- #{path}"
         begin
           compression_type = (

--- a/recipes/users.rb
+++ b/recipes/users.rb
@@ -29,7 +29,13 @@ upload_users = data_bag_item('users', 'upload').select { |uname| uname != 'id' }
 
 evertrue_gid = 'evertrue'
 upload_users.each do |uname, u|
-  u['home'] = "#{node['et_upload']['base_dir']}/users/#{uname}"
+  # If a parent_user and partner have been provided then the user's home folder is the partner directory under the parent_user's home folder
+  if u['parent_user'] && u['partner']
+    u['home'] = "#{node['et_upload']['base_dir']}/users/#{u['parent_user']}/#{u['partner']}"
+  else
+    u['home'] = "#{node['et_upload']['base_dir']}/users/#{uname}"
+  end
+
   u['gid'] = 'uploadonly'
 
   if u['action'] == 'remove'


### PR DESCRIPTION
This PR adds support for hosting a separate SFTP user and home folder for an org's partner integration such as hustle.  The partner home and subfolders are located under the org's home folder.  When upload files are processed, the files will be retrieved from any uploads folder under the org's home folder, which will include the partner uploads folder.

I updated the readme to include a description of each script file, including example user objects for a normal org user and for a partner user.